### PR TITLE
feat: add artifact and typechain exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ artifacts/
 node_modules/
 cache/
 deployments/
+build/
+contract-types/

--- a/contracts/insured-bridge/RateModelStore.sol
+++ b/contracts/insured-bridge/RateModelStore.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "../common/implementation/MultiCaller.sol";
+
+/**
+ * @title Maps rate model objects to L1 token.
+ * @dev This contract is designed to be queried by off-chain relayers that need to compute realized LP fee %'s before
+ * submitting relay transactions to a BridgePool contract. Therefore, this contract does not perform any validation on
+ * the shape of the rate model, which is stored as a string to enable arbitrary data encoding via a stringified JSON
+ * object. This leaves this contract unopionated on the parameters within the rate model, enabling governance to adjust
+ * the structure in the future.
+ */
+contract RateModelStore is Ownable, MultiCaller {
+    mapping(address => string) public l1TokenRateModels;
+
+    event UpdatedRateModel(address indexed l1Token, string rateModel);
+
+    /**
+     * @notice Updates rate model string for L1 token.
+     * @param l1Token the l1 token rate model to update.
+     * @param rateModel the updated rate model.
+     */
+    function updateRateModel(address l1Token, string memory rateModel) external onlyOwner {
+        l1TokenRateModels[l1Token] = rateModel;
+        emit UpdatedRateModel(l1Token, rateModel);
+    }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,6 +15,8 @@ const configOverride = {
 
 const hardhatConfig = getHardhatConfig(configOverride, __dirname, false);
 
+require("./tasks/acrossPool");
+
 // To allow customizing the chain id when forking, allow the user to provide an env variable.
 if (process.env.HARDHAT_CHAIN_ID) hardhatConfig.networks.hardhat.chainId = parseInt(process.env.HARDHAT_CHAIN_ID);
 

--- a/networks/1.json
+++ b/networks/1.json
@@ -4,19 +4,29 @@
       "address": "0x30B44C676A05F1264d1dE9cC31dB5F2A945186b6"
     },
     {
-      "contractName": "BridgePool",
-      "deploymentName": "WETHBridgePool",
+      "contractName": "BridgePoolProd",
+      "deploymentName": "WETH_BridgePool",
       "address": "0x7355Efc63Ae731f584380a9838292c7046c1e433"
     },
     {
-      "contractName": "BridgePool",
-      "deploymentName": "USDCBridgePool",
+      "contractName": "BridgePoolProd",
+      "deploymentName": "USDC_BridgePool",
       "address": "0x256C8919CE1AB0e33974CF6AA9c71561Ef3017b6"
     },
     {
-      "contractName": "BridgePool",
-      "deploymentName": "UMABridgePool",
+      "contractName": "BridgePoolProd",
+      "deploymentName": "UMA_BridgePool",
       "address": "0xdfe0ec39291e3b60ACa122908f86809c9eE64E90"
+    },
+    {
+      "contractName": "BridgePoolProd",
+      "deploymentName": "BADGER_BridgePool",
+      "address": "0x43298F9f91a4545dF64748e78a2c777c580573d6"
+    },
+    {
+      "contractName": "BridgePoolProd",
+      "deploymentName": "WBTC_BridgePool",
+      "address": "0x02fbb64517E1c6ED69a6FAa3ABf37Db0482f1152"
     },
     {
       "contractName": "Arbitrum_Messenger",
@@ -29,5 +39,9 @@
     {
       "contractName": "Optimism_Wrapper",
       "address": "0xcFfB47DC5Bd4f6Dc475E98fF92647a583389Ee08"
+    },
+    {
+      "contractName": "RateModelStore",
+      "address": "0xd18fFeb5fdd1F2e122251eA7Bf357D8Af0B60B50"
     }
 ]

--- a/networks/288.json
+++ b/networks/288.json
@@ -1,0 +1,6 @@
+[
+    {
+      "contractName": "OVM_OETH_BridgeDepositBox",
+      "address": "0xCD43CEa89DF8fE39031C03c24BC24480e942470B"
+    }
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Across smart contracts and tests",
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.5",
@@ -20,9 +20,9 @@
     "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-web3": "^2.0.0",
-    "@typechain/ethers-v5": "^8.0.5",
-    "@typechain/hardhat": "^3.1.0",
-    "@typechain/web3-v1": "^4.0.0",
+    "@typechain/ethers-v5": "7.0.1",
+    "@typechain/hardhat": "2.2.0",
+    "@typechain/web3-v1": "3.0.0",
     "@uma/common": "^2.14.0",
     "@uma/contracts-node": "^0.1.15",
     "@uniswap/v3-core": "^1.0.0-rc.2",
@@ -32,7 +32,7 @@
     "glob": "^7.2.0",
     "hardhat": "^2.6.8",
     "lodash.uniqby": "^4.7.0",
-    "typechain": "^6.0.0"
+    "typechain": "5.1.2"
   },
   "homepage": "https://across.to",
   "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Across smart contracts and tests",
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Across smart contracts and tests",
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Across smart contracts and tests",
   "dependencies": {
     "@eth-optimism/contracts": "^0.5.5",
@@ -20,6 +20,9 @@
     "@nomiclabs/hardhat-etherscan": "^2.1.6",
     "@nomiclabs/hardhat-truffle5": "^2.0.0",
     "@nomiclabs/hardhat-web3": "^2.0.0",
+    "@typechain/ethers-v5": "^8.0.5",
+    "@typechain/hardhat": "^3.1.0",
+    "@typechain/web3-v1": "^4.0.0",
     "@uma/common": "^2.14.0",
     "@uma/contracts-node": "^0.1.15",
     "@uniswap/v3-core": "^1.0.0-rc.2",
@@ -27,7 +30,9 @@
     "decimal.js": "^10.3.1",
     "ethers": "^5.5.2",
     "glob": "^7.2.0",
-    "hardhat": "^2.6.8"
+    "hardhat": "^2.6.8",
+    "lodash.uniqby": "^4.7.0",
+    "typechain": "^6.0.0"
   },
   "homepage": "https://across.to",
   "license": "AGPL-3.0-or-later",
@@ -44,13 +49,15 @@
   "files": [
     "/contracts/**/*.sol",
     "/artifacts/**/*",
-    "/dist/**/*",
-    "/types/**/*"
+    "/build/**/*",
+    "/contract-types/**/*",
+    "/networks/**/*"
   ],
   "sideEffects": false,
   "scripts": {
     "test": "mocha 'test/**/*.js'",
-    "build": "hardhat compile && yarn load-addresses",
+    "build": "hardhat compile && yarn typechain && yarn load-addresses && ./scripts/build.js",
+    "typechain": "TYPECHAIN=web3 yarn hardhat typechain && TYPECHAIN=ethers yarn hardhat typechain",
     "load-addresses": "yarn hardhat load-addresses",
     "prepublish": "yarn build"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+const hre = require("hardhat");
+const uniqBy = require("lodash.uniqby");
+const fs = require("fs");
+const path = require("path");
+
+
+async function main() {
+    const artifactPaths = await hre.artifacts.getArtifactPaths();
+
+    const json = uniqBy(
+        artifactPaths.map((artifactPath) => ({
+          contractName: path.basename(artifactPath).split(".")[0],
+          relativePath: `./${path.relative(path.join(__dirname, ".."), artifactPath)}`
+        })),
+        "contractName"
+      );
+
+    const buildDir = path.join(__dirname, "..", "build");
+
+    if (!fs.existsSync(buildDir)){
+      fs.mkdirSync(buildDir);
+    }
+
+    fs.writeFileSync(path.join(buildDir, "artifacts.json"), JSON.stringify(json, undefined, 2));
+}
+
+main().then(
+    () => process.exit(0),
+    (error) => {
+        console.log(error);
+        process.exit(1);
+    }
+);

--- a/tasks/acrossPool.js
+++ b/tasks/acrossPool.js
@@ -1,0 +1,35 @@
+const { task, types } = require("hardhat/config");
+const { ZERO_ADDRESS } = require("@uma/common");
+
+task("deploy-across-pool", "Deploys an L1 across pool and whitelists it within the BridgeAdmin")
+  .addParam("lptokenname", "Name of the LP tokens deployed for the pool", undefined, types.string)
+  .addParam("lptokensymbol", "Symbol of the LP tokens deployed for the pool", undefined, types.string)
+  .addParam("l1tokenaddress", "Address of the token on L1", undefined, types.string)
+  .addParam("lpfeeratepersecond", "Scales the amount of pending fees per second paid to LPs", undefined, types.string)
+  .addParam("iswethpool", "Set if this is the across weth pool", undefined, types.string)
+  .setAction(async function (taskArguments, hre) {
+    const { deployments, getNamedAccounts, web3 } = hre;
+    const { deploy } = deployments;
+    const { deployer } = await getNamedAccounts();
+    const { lptokenname, lptokensymbol, l1tokenaddress, lpfeeratepersecond, iswethpool } = taskArguments;
+
+    const BridgeAdmin = await deployments.get("BridgeAdmin");
+    const bridgeAdmin = new web3.eth.Contract(BridgeAdmin.abi, BridgeAdmin.address);
+    console.log(`Loaded BridgeAdmin @ ${bridgeAdmin.options.address}`);
+
+    const args = [
+      lptokenname, // _lpTokenName
+      lptokensymbol, // _lpTokenSymbol
+      bridgeAdmin.options.address, // _bridgeAdmin
+      l1tokenaddress, // _l1Token
+      lpfeeratepersecond, // _lpFeeRatePerSecond
+      Boolean(JSON.parse(iswethpool)), // _isWethPool
+      ZERO_ADDRESS, // _timer
+    ];
+
+    console.log(`Deploying bridgePool from ${deployer}`, args);
+
+    const bridgePool = await deploy("BridgePoolProd", { from: deployer, args, log: true });
+
+    console.log("Bridge pool deployed @ ", bridgePool.address);
+  });

--- a/tasks/acrossPool.js
+++ b/tasks/acrossPool.js
@@ -1,7 +1,7 @@
 const { task, types } = require("hardhat/config");
 const { ZERO_ADDRESS } = require("@uma/common");
 
-task("deploy-across-pool", "Deploys an L1 across pool and whitelists it within the BridgeAdmin")
+task("deploy-pool", "Deploys an L1 across pool and whitelists it within the BridgeAdmin")
   .addParam("lptokenname", "Name of the LP tokens deployed for the pool", undefined, types.string)
   .addParam("lptokensymbol", "Symbol of the LP tokens deployed for the pool", undefined, types.string)
   .addParam("l1tokenaddress", "Address of the token on L1", undefined, types.string)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,9 +1992,9 @@
     "@types/node" "*"
 
 "@types/prettier@^2.1.1":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
-  integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
+  integrity sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
 
 "@types/prompts@^2.0.14":
   version "2.0.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1859,6 +1859,29 @@
     xhr "^2.2.0"
     xtend "^4.0.1"
 
+"@typechain/ethers-v5@^8.0.5":
+  version "8.0.5"
+  resolved "https://registry.yarnpkg.com/@typechain/ethers-v5/-/ethers-v5-8.0.5.tgz#d469420e9a73deb7fa076cde9edb45d713dd1b8c"
+  integrity sha512-ntpj4cS3v4WlDu+hSKSyj9A3o1tKtWC30RX1gobeYymZColeJiUemC1Kgfa0MWGmInm5CKxoHVhEvYVgPOZn1A==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
+"@typechain/hardhat@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@typechain/hardhat/-/hardhat-3.1.0.tgz#88bd9e9d55e30fbece6fbb34c03ecd40a8b2013a"
+  integrity sha512-C6Be6l+vTpao19PvMH2CB/lhL1TRLkhdPkvQCF/zqkY1e+0iqY2Bb9Jd3PTt6I8QvMm89ZDerrCJC9927ZHmlg==
+  dependencies:
+    fs-extra "^9.1.0"
+
+"@typechain/web3-v1@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@typechain/web3-v1/-/web3-v1-4.0.0.tgz#938f745579c4c4d3991f806437259308d08498f1"
+  integrity sha512-UpUV+BB9Gcmmhw3P5lCawSOai8ivbRHglOqPnSCLau/w5lbw6mA5nAR2eI2tLfaC6vJoN5YDUYh+pvX5aXrt8A==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
 "@types/abstract-leveldown@*":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.2.tgz#ee81917fe38f770e29eec8139b6f16ee4a8b0a5f"
@@ -1967,6 +1990,11 @@
   integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
   dependencies:
     "@types/node" "*"
+
+"@types/prettier@^2.1.1":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.2.tgz#4c62fae93eb479660c3bd93f9d24d561597a8281"
+  integrity sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==
 
 "@types/prompts@^2.0.14":
   version "2.0.14"
@@ -2434,6 +2462,16 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-back@^3.0.1, array-back@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2544,6 +2582,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -3645,7 +3688,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.1:
+chalk@^4.1.0, chalk@^4.1.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3922,6 +3965,26 @@ command-exists@^1.2.8:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
+
+command-line-args@^5.1.1:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.2.0.tgz#087b02748272169741f1fd7c785b295df079b9be"
+  integrity sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==
+  dependencies:
+    array-back "^3.1.0"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
+command-line-usage@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  integrity sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==
+  dependencies:
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@3.0.2:
   version "3.0.2"
@@ -4306,7 +4369,7 @@ deep-equal@~1.1.1:
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
 
-deep-extend@^0.6.0:
+deep-extend@^0.6.0, deep-extend@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
@@ -5776,6 +5839,13 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
+
 find-up@3.0.0, find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -5932,7 +6002,7 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -5949,6 +6019,16 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs-minipass@^1.2.7:
   version "1.2.7"
@@ -6175,7 +6255,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.2.0:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -8212,7 +8292,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*:
+mkdirp@*, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -9141,6 +9221,11 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
+prettier@^2.1.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 printj@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
@@ -9488,6 +9573,11 @@ recursive-readdir@^2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 regenerate@^1.2.1:
   version "1.4.2"
@@ -10367,6 +10457,11 @@ strict-uri-encode@^1.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
+string-format@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
+  integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -10599,6 +10694,16 @@ sync-rpc@^1.2.1:
   dependencies:
     get-port "^3.1.0"
 
+table-layout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
+  dependencies:
+    array-back "^4.0.1"
+    deep-extend "~0.6.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
+
 tapable@^0.2.7:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.9.tgz#af2d8bbc9b04f74ee17af2b4d9048f807acd18a8"
@@ -10822,6 +10927,21 @@ truffle-deploy-registry@^0.5.1:
     mkdirp "^0.5.1"
     rimraf "^2.6.3"
 
+ts-command-line-args@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-command-line-args/-/ts-command-line-args-2.2.0.tgz#655e10451b06c86d318e9467546da4d19b773a55"
+  integrity sha512-RedEejZyhiEAOgBkIVxB4QC/SRYtl98D7b7epWB9e6E+TmK8KstXBu3WdnhGbMHicLkHoG7sCAmu+F+ASzLFHA==
+  dependencies:
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-usage "^6.1.0"
+    string-format "^2.0.0"
+
+ts-essentials@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
+
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -10904,6 +11024,22 @@ type@^2.5.0:
   resolved "https://registry.yarnpkg.com/type/-/type-2.5.0.tgz#0a2e78c2e77907b252abe5f298c1b01c63f0db3d"
   integrity sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==
 
+typechain@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/typechain/-/typechain-6.1.0.tgz#462a35f555accf870689d1ba5698749108d0ce81"
+  integrity sha512-GGfkK0p3fUgz8kYxjSS4nKcWXE0Lo+teHTetghousIK5njbNoYNDlwn91QIyD181L3fVqlTvBE0a/q3AZmjNfw==
+  dependencies:
+    "@types/prettier" "^2.1.1"
+    debug "^4.1.1"
+    fs-extra "^7.0.0"
+    glob "^7.1.6"
+    js-sha3 "^0.8.0"
+    lodash "^4.17.15"
+    mkdirp "^1.0.4"
+    prettier "^2.1.2"
+    ts-command-line-args "^2.2.0"
+    ts-essentials "^7.0.1"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -10915,6 +11051,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 u2f-api@0.2.7:
   version "0.2.7"
@@ -12092,6 +12238,14 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
+  dependencies:
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
This adds typechain and an artifact json export that details the artifact locations. This will allow importers of this package to run post-processing on the contracts and their hardhat artifacts.